### PR TITLE
Update homio_room.yaml

### DIFF
--- a/dashboards/templates/button_cards/cards/homio_room.yaml
+++ b/dashboards/templates/button_cards/cards/homio_room.yaml
@@ -1,4 +1,6 @@
 homio_room:
+  triggers_update:
+    - '[[[ return variables.motion_sensor ]]]'
   variables:
     show_motion: false
     motion_sensor: variables.montion_sensor


### PR DESCRIPTION
Added `triggers_update` because without it, the 'motion detected' banner won't show up or hide without refreshing the page.