### PR TITLE
Update configuration.yaml

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -25,7 +25,7 @@ lovelace:
       url: "/local/community/light-slider/my-slider-v2.js"
     - type: "css"
       url: "https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@100..900&display=swap"
-dashboards:
+  dashboards:
     dashboard-homio:
       mode: yaml
       title: "homio"


### PR DESCRIPTION
fix(configuration): move dashboards under lovelace block

The 'dashboards' section was incorrectly placed at the root level. It has been moved under the 'lovelace' configuration block to ensure proper parsing by Home Assistant.