### PR TITLE
Fix default sensor variables in homio_room template

### DIFF
--- a/dashboards/templates/button_cards/cards/homio_room.yaml
+++ b/dashboards/templates/button_cards/cards/homio_room.yaml
@@ -3,11 +3,11 @@ homio_room:
     - '[[[ return variables.motion_sensor ]]]'
   variables:
     show_motion: false
-    motion_sensor: variables.motion_sensor
+    motion_sensor: ""
     show_temp: false
-    temp_sensor: variables.temp_sensor
+    temp_sensor: ""
     show_humid: false
-    humid_sensor: variables.humid_sensor
+    humid_sensor: ""
   template:
     - homio_default
   tap_action:


### PR DESCRIPTION
The default values for motion_sensor, temp_sensor, and humid_sensor were set to the literal strings "variables.motion_sensor", "variables.temp_sensor", and "variables.humid_sensor" respectively.

When a user doesn't provide these sensor variables (e.g. setting show_temp: false without a temp_sensor), the JavaScript template checks like `if (!variables.motion_sensor)` evaluate as truthy because they contain non-empty strings. This then causes the template to attempt `states["variables.motion_sensor"]` which throws:

ButtonCardJSTemplateError: Cannot read properties of undefined (reading 'state')

Changed the defaults to empty strings so the falsy checks work correctly when sensors aren't provided.